### PR TITLE
Firewall policy support with Unifi Network v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Unifi Network Rules Custom Integration
 
-Pulls firewall, traffic rules, and traffic routes from your Unifi Dream Machine and allows you to enable/disable them in Home Assistant.
+Pulls firewall policies and traffic routes from your Unifi Dream Machine and allows you to enable/disable them in Home Assistant.
+
+## Requirements
+
+A Unifi Dream Machine (UDM) running network application 9.0.92 or later.
+
+> [!NOTE]
+> For version 8.x.x of the Unifi Network application, please use the v.0.3.x release of this integration.
 
 ## Installation
 
@@ -28,7 +35,7 @@ THEN
 
 ## Usage
 
-Once you have configured the integration, you will be able to see the firewall rules and traffic routes configured on your Unifi Network as switches in Home Assistant. Add the switch to a custom dashboard or use it in automations just like any other Home Assistant switch.
+Once you have configured the integration, you will be able to see the firewall policies and traffic routes configured on your Unifi Network as switches in Home Assistant. Add the switch to a custom dashboard or use it in automations just like any other Home Assistant switch.
 
 ## Local Development
 

--- a/custom_components/unifi_network_rules/__init__.py
+++ b/custom_components/unifi_network_rules/__init__.py
@@ -19,73 +19,69 @@ PLATFORMS: list[str] = ["switch"]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the UDM Rule Manager component."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
+   """Set up the UDM Rule Manager component."""
+   hass.data.setdefault(DOMAIN, {})
+   return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up UDM Rule Manager from a config entry."""
-    host = entry.data[CONF_HOST]
-    username = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
-    update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-    max_retries = entry.data.get(CONF_MAX_RETRIES, DEFAULT_MAX_RETRIES)
-    retry_delay = entry.data.get(CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY)
+   """Set up UDM Rule Manager from a config entry."""
+   host = entry.data[CONF_HOST]
+   username = entry.data[CONF_USERNAME]
+   password = entry.data[CONF_PASSWORD]
+   update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+   max_retries = entry.data.get(CONF_MAX_RETRIES, DEFAULT_MAX_RETRIES)
+   retry_delay = entry.data.get(CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY)
 
-    api = UDMAPI(host, username, password, max_retries=max_retries, retry_delay=retry_delay)
-    
-    # Test the connection
-    success, error_message = await api.login()
-    if not success:
-        raise ConfigEntryNotReady(f"Failed to connect to UDM: {error_message}")
+   api = UDMAPI(host, username, password, max_retries=max_retries, retry_delay=retry_delay)
+   
+   # Test the connection
+   success, error_message = await api.login()
+   if not success:
+       raise ConfigEntryNotReady(f"Failed to connect to UDM: {error_message}")
 
-    async def async_update_data():
-        """Fetch data from API."""
-        try:
-            traffic_success, traffic_rules, traffic_error = await api.get_traffic_rules()
-            firewall_success, firewall_rules, firewall_error = await api.get_firewall_rules()
-            routes_success, traffic_routes, routes_error = await api.get_traffic_routes()
+   async def async_update_data():
+    """Fetch data from API."""
+    try:
+        policies_success, policies, policies_error = await api.get_firewall_policies()
+        routes_success, traffic_routes, routes_error = await api.get_traffic_routes()
 
-            if not traffic_success:
-                raise Exception(f"Failed to fetch traffic rules: {traffic_error}")
-            if not firewall_success:
-                raise Exception(f"Failed to fetch firewall rules: {firewall_error}")
-            if not routes_success:
-                raise Exception(f"Failed to fetch traffic routes: {routes_error}")
+        if not policies_success:
+            raise Exception(f"Failed to fetch firewall policies: {policies_error}")
+        if not routes_success:
+            raise Exception(f"Failed to fetch traffic routes: {routes_error}")
 
-            return {
-                "traffic_rules": traffic_rules,
-                "firewall_rules": firewall_rules,
-                "traffic_routes": traffic_routes
-            }
-        except Exception as e:
-            _LOGGER.error(f"Error updating data: {str(e)}")
-            raise
+        return {
+            "firewall_policies": policies,
+            "traffic_routes": traffic_routes
+        }
+    except Exception as e:
+        _LOGGER.error(f"Error updating data: {str(e)}")
+        raise
 
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="udm_rule_manager",
-        update_method=async_update_data,
-        update_interval=timedelta(minutes=update_interval),
-    )
+   coordinator = DataUpdateCoordinator(
+       hass,
+       _LOGGER,
+       name="udm_rule_manager",
+       update_method=async_update_data,
+       update_interval=timedelta(minutes=update_interval),
+   )
 
-    # Fetch initial data
-    await coordinator.async_config_entry_first_refresh()
+   # Fetch initial data
+   await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        'api': api,
-        'coordinator': coordinator
-    }
+   hass.data[DOMAIN][entry.entry_id] = {
+       'api': api,
+       'coordinator': coordinator
+   }
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+   await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    return True
+   return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+   """Unload a config entry."""
+   unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+   if unload_ok:
+       hass.data[DOMAIN].pop(entry.entry_id)
 
-    return unload_ok
+   return unload_ok

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",    
     "issue_tracker": "https://github.com/sirkirby/ha_udm_rule_manager/issues",
     "requirements": ["aiohttp"],
-    "version": "0.3.0"
+    "version": "1.0.0"
 }

--- a/custom_components/unifi_network_rules/switch.py
+++ b/custom_components/unifi_network_rules/switch.py
@@ -18,96 +18,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     entities = []
 
-    if coordinator.data.get('traffic_rules'):
-        for rule in coordinator.data['traffic_rules']:
-            entities.append(UDMTrafficRuleSwitch(coordinator, api, rule))
+    for policy in coordinator.data.get('firewall_policies', []):
+        entities.append(UDMFirewallPolicySwitch(coordinator, api, policy))
 
-    if coordinator.data.get('firewall_rules'):
-        for rule in coordinator.data['firewall_rules']:
-            entities.append(UDMFirewallRuleSwitch(coordinator, api, rule))
-
-    if coordinator.data.get('traffic_routes'):
-        for route in coordinator.data['traffic_routes']:
-            entities.append(UDMTrafficRouteSwitch(coordinator, api, route))
+    for route in coordinator.data.get('traffic_routes', []):
+        entities.append(UDMTrafficRouteSwitch(coordinator, api, route))
 
     async_add_entities(entities, True)
-
-class UDMRuleSwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of a UDM Rule Switch."""
-
-    def __init__(self, coordinator, api, rule, rule_type):
-        """Initialize the UDM Rule Switch."""
-        super().__init__(coordinator)
-        self._api = api
-        self._rule_type = rule_type
-        self._attr_unique_id = f"{rule_type}_{rule['_id']}"
-        self._attr_name = f"{rule_type.capitalize()} Rule: {rule.get('description', rule.get('name', 'Unnamed'))}"
-
-    @property
-    def is_on(self):
-        """Return true if the switch is on."""
-        rule = self._get_rule()
-        return rule['enabled'] if rule else False
-
-    async def async_turn_on(self, **kwargs):
-        """Turn the switch on."""
-        await self._toggle(True)
-
-    async def async_turn_off(self, **kwargs):
-        """Turn the switch off."""
-        await self._toggle(False)
-
-    async def _toggle(self, new_state):
-        """Toggle the rule state."""
-        rule = self._get_rule()
-        if not rule:
-            raise HomeAssistantError(f"{self._rule_type.capitalize()} rule not found")
-
-        _LOGGER.debug(f"Attempting to set {self._rule_type} rule {rule['_id']} to {'on' if new_state else 'off'}")
-        
-        try:
-            if self._rule_type == 'traffic':
-                success, error_message = await self._api.toggle_traffic_rule(rule['_id'], new_state)
-            else:
-                success, error_message = await self._api.toggle_firewall_rule(rule['_id'], new_state)
-
-            if success:
-                _LOGGER.info(f"Successfully set {self._rule_type} rule {rule['_id']} to {'on' if new_state else 'off'}")
-                await self.coordinator.async_request_refresh()
-            else:
-                _LOGGER.error(f"Failed to set {self._rule_type} rule {rule['_id']} to {'on' if new_state else 'off'}. Error: {error_message}")
-                raise HomeAssistantError(f"Failed to toggle {self._rule_type} rule: {error_message}")
-        
-        except Exception as e:
-            _LOGGER.error(f"Error toggling {self._rule_type} rule {rule['_id']}: {str(e)}")
-            raise HomeAssistantError(f"Error toggling {self._rule_type} rule: {str(e)}")
-
-    def _get_rule(self):
-        """Get the current rule from the coordinator data."""
-        rules = self.coordinator.data.get(f'{self._rule_type}_rules', [])
-        for rule in rules:
-            if rule['_id'] == self._attr_unique_id.split('_')[1]:
-                return rule
-        return None
-
-    @callback
-    def _handle_coordinator_update(self):
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()
-
-class UDMTrafficRuleSwitch(UDMRuleSwitch):
-    """Representation of a UDM Traffic Rule Switch."""
-
-    def __init__(self, coordinator, api, rule):
-        """Initialize the UDM Traffic Rule Switch."""
-        super().__init__(coordinator, api, rule, 'traffic')
-
-class UDMFirewallRuleSwitch(UDMRuleSwitch):
-    """Representation of a UDM Firewall Rule Switch."""
-
-    def __init__(self, coordinator, api, rule):
-        """Initialize the UDM Firewall Rule Switch."""
-        super().__init__(coordinator, api, rule, 'firewall')
 
 class UDMTrafficRouteSwitch(CoordinatorEntity, SwitchEntity):
     """Representation of a UDM Traffic Route Switch."""
@@ -118,26 +35,13 @@ class UDMTrafficRouteSwitch(CoordinatorEntity, SwitchEntity):
         self._api = api
         self._attr_unique_id = f"traffic_route_{route['_id']}"
         self._attr_name = f"Traffic Route: {route.get('description', 'Unnamed')}"
-        
-        # Store route details for device info
-        self._route = route
+        self._route_id = route['_id']
 
     @property
     def is_on(self):
         """Return true if the switch is on."""
         route = self._get_route()
         return route['enabled'] if route else False
-
-    @property
-    def device_info(self):
-        """Return device info for this traffic route."""
-        return {
-            "identifiers": {(DOMAIN, self._attr_unique_id)},
-            "name": self._attr_name,
-            "manufacturer": "Ubiquiti",
-            "model": "Traffic Route",
-            "sw_version": None,
-        }
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
@@ -149,33 +53,19 @@ class UDMTrafficRouteSwitch(CoordinatorEntity, SwitchEntity):
 
     async def _toggle(self, new_state):
         """Toggle the route state."""
-        route = self._get_route()
-        if not route:
-            raise HomeAssistantError("Traffic route not found")
-
-        _LOGGER.debug(f"Attempting to set traffic route {route['_id']} to {'on' if new_state else 'off'}")
-        
         try:
-            success, error_message = await self._api.toggle_traffic_route(route['_id'], new_state)
+            success, error_message = await self._api.toggle_traffic_route(self._route_id, new_state)
             if success:
-                _LOGGER.info(f"Successfully set traffic route {route['_id']} to {'on' if new_state else 'off'}")
                 await self.coordinator.async_request_refresh()
             else:
-                _LOGGER.error(f"Failed to set traffic route {route['_id']} to {'on' if new_state else 'off'}. Error: {error_message}")
                 raise HomeAssistantError(f"Failed to toggle traffic route: {error_message}")
-        
         except Exception as e:
-            _LOGGER.error(f"Error toggling traffic route {route['_id']}: {str(e)}")
             raise HomeAssistantError(f"Error toggling traffic route: {str(e)}")
 
     def _get_route(self):
         """Get the current route from the coordinator data."""
         routes = self.coordinator.data.get('traffic_routes', [])
-        route_id = self._attr_unique_id.split('_')[-1]
-        for route in routes:
-            if route['_id'] == route_id:
-                return route
-        return None
+        return next((r for r in routes if r['_id'] == self._route_id), None)
 
     @property
     def extra_state_attributes(self):
@@ -191,11 +81,9 @@ class UDMTrafficRouteSwitch(CoordinatorEntity, SwitchEntity):
             "kill_switch_enabled": route.get("kill_switch_enabled", False),
         }
 
-        # Add domain information if available
         if route.get("domains"):
             attributes["domains"] = [d.get("domain") for d in route["domains"]]
 
-        # Add target devices information
         if route.get("target_devices"):
             devices = []
             for device in route["target_devices"]:
@@ -208,3 +96,64 @@ class UDMTrafficRouteSwitch(CoordinatorEntity, SwitchEntity):
             attributes["target_devices"] = devices
 
         return attributes
+
+class UDMFirewallPolicySwitch(CoordinatorEntity, SwitchEntity):
+   """Representation of a UDM Firewall Policy Switch."""
+
+   def __init__(self, coordinator, api, policy):
+       """Initialize the UDM Firewall Policy Switch."""
+       super().__init__(coordinator)
+       self._api = api
+       self._attr_unique_id = f"firewall_policy_{policy['_id']}"
+       self._attr_name = f"Firewall Policy: {policy.get('name', 'Unnamed')}"
+       self._policy_id = policy['_id']
+
+   @property
+   def is_on(self):
+       """Return true if the switch is on."""
+       policy = self._get_policy()
+       return policy['enabled'] if policy else False
+
+   async def async_turn_on(self, **kwargs):
+       """Turn the switch on."""
+       await self._toggle(True)
+
+   async def async_turn_off(self, **kwargs):
+       """Turn the switch off."""
+       await self._toggle(False)
+
+   async def _toggle(self, new_state):
+       """Toggle the policy state."""
+       try:
+           success, error_message = await self._api.toggle_firewall_policy(self._policy_id, new_state)
+           if success:
+               await self.coordinator.async_request_refresh()
+           else:
+               raise HomeAssistantError(f"Failed to toggle firewall policy: {error_message}")
+       except Exception as e:
+           raise HomeAssistantError(f"Error toggling firewall policy: {str(e)}")
+
+   def _get_policy(self):
+        """Get the current policy from the coordinator data."""
+        policies = self.coordinator.data.get('firewall_policies', [])
+        return next((p for p in policies if p['_id'] == self._policy_id), None)
+
+   @property
+   def extra_state_attributes(self):
+    """Return additional state attributes."""
+    policy = self._get_policy()
+    if not policy:
+        return {}
+
+    return {
+        "name": policy.get("name", ""),
+        "action": policy.get("action", ""),
+        "predefined": policy.get("predefined", False),
+        "protocol": policy.get("protocol", ""),
+        "schedule_mode": policy.get("schedule", {}).get("mode", ""),
+        "source_zone": policy.get("source", {}).get("zone_id", ""),
+        "destination_zone": policy.get("destination", {}).get("zone_id", ""),
+        "index": policy.get("index", 0),
+        "matching_target": policy.get("source", {}).get("matching_target", ""),
+        "ip_version": policy.get("ip_version", "")
+    }

--- a/tests/test_udm_api.py
+++ b/tests/test_udm_api.py
@@ -8,522 +8,247 @@ from custom_components.unifi_network_rules.udm_api import UDMAPI
 
 @pytest.fixture
 def udm_api():
-    return UDMAPI("192.168.1.1", "admin", "password")
+   return UDMAPI("192.168.1.1", "admin", "password")
 
 @pytest.mark.asyncio
 async def test_login_success(udm_api):
-    with patch('aiohttp.ClientSession.post') as mock_post:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.cookies = {'cookie': 'value'}
-        mock_response.headers = {'x-csrf-token': 'token'}
-        mock_post.return_value.__aenter__.return_value = mock_response
+   with patch('aiohttp.ClientSession.post') as mock_post:
+       mock_response = Mock()
+       mock_response.status = 200
+       mock_response.cookies = {'cookie': 'value'}
+       mock_response.headers = {'x-csrf-token': 'token'}
+       mock_post.return_value.__aenter__.return_value = mock_response
 
-        success, error = await udm_api.login()
+       success, error = await udm_api.login()
 
-        assert success == True
-        assert error is None
-        assert udm_api.cookies == {'cookie': 'value'}
-        assert udm_api.csrf_token == 'token'
+       assert success == True
+       assert error is None
+       assert udm_api.cookies == {'cookie': 'value'}
+       assert udm_api.csrf_token == 'token'
 
-pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_ensure_logged_in_success(udm_api):
-    udm_api.cookies = {'cookie': 'value'}
-    udm_api.csrf_token = 'token'
-    udm_api.last_login = datetime.now()
+   udm_api.cookies = {'cookie': 'value'}
+   udm_api.csrf_token = 'token'
+   udm_api.last_login = datetime.now()
 
-    with patch.object(udm_api, 'login') as mock_login:
-        result = await udm_api.ensure_logged_in()
+   with patch.object(udm_api, 'login') as mock_login:
+       result = await udm_api.ensure_logged_in()
 
-        assert result == True
-        mock_login.assert_not_called()
-
-@pytest.mark.asyncio
-async def test_ensure_logged_in_expired(udm_api):
-    udm_api.cookies = {'cookie': 'value'}
-    udm_api.csrf_token = 'token'
-    udm_api.last_login = datetime.now() - udm_api.session_timeout - timedelta(minutes=1)
-
-    with patch.object(udm_api, 'login') as mock_login:
-        mock_login.return_value = (True, None)
-        result = await udm_api.ensure_logged_in()
-
-        assert result == True
-        mock_login.assert_called_once()
+       assert result == True
+       mock_login.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_ensure_logged_in_failed(udm_api):
-    udm_api.cookies = None
-    udm_api.csrf_token = None
-    udm_api.last_login = None
+async def test_get_firewall_policies_success(udm_api):
+   mock_policies = [{"_id": "1", "enabled": True}, {"_id": "2", "enabled": False}]
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (True, mock_policies, None)
 
-    with patch.object(udm_api, 'login') as mock_login:
-        mock_login.return_value = (False, "Login failed")
-        result = await udm_api.ensure_logged_in()
+       success, policies, error = await udm_api.get_firewall_policies()
 
-        assert result == False
-        mock_login.assert_called_once()
-
-@pytest.mark.asyncio
-async def test_get_traffic_rules_success(udm_api):
-    mock_rules = [{"_id": "1", "enabled": True}]
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, mock_rules, None)
-
-        success, rules, error = await udm_api.get_traffic_rules()
-
-        assert success == True
-        assert rules == mock_rules
-        assert error is None
+       assert success is True
+       assert policies == mock_policies
+       assert error is None
 
 @pytest.mark.asyncio
-async def test_get_traffic_rules_failure(udm_api):
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (False, None, "Failed to fetch traffic rules")
+async def test_get_firewall_policies_failure(udm_api):
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (False, None, "API Error")
 
-        success, rules, error = await udm_api.get_traffic_rules()
+       success, policies, error = await udm_api.get_firewall_policies()
 
-        assert success == False
-        assert rules is None
-        assert error == "Failed to fetch traffic rules"
-
-@pytest.mark.asyncio
-async def test_get_firewall_rules_success(udm_api):
-    mock_rules = [{"_id": "1", "enabled": True}, {"_id": "2", "enabled": False}]
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, {"data": mock_rules}, None)
-
-        success, rules, error = await udm_api.get_firewall_rules()
-
-        assert success == True
-        assert rules == mock_rules
-        assert error is None
+       assert success is False
+       assert policies is None
+       assert "API Error" in error
 
 @pytest.mark.asyncio
-async def test_get_firewall_rules_failure(udm_api):
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (False, None, "Failed to fetch firewall rules")
-
-        success, rules, error = await udm_api.get_firewall_rules()
-
-        assert success == False
-        assert rules is None
-        assert error == "Failed to fetch firewall rules"
-
-@pytest.mark.asyncio
-async def test_toggle_traffic_rule_success(udm_api):
-    rule_id = "1"
-    enabled = True
-    mock_rule = {"_id": rule_id, "enabled": not enabled}
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.side_effect = [
-            (True, mock_rule, None),  # GET request
-            (True, None, None)  # PUT request
-        ]
-
-        success, error = await udm_api.toggle_traffic_rule(rule_id, enabled)
-
-        assert success == True
-        assert error is None
-        assert mock_request.call_count == 2
+async def test_get_firewall_policy_success(udm_api):
+   policy_id = "test_id"
+   mock_policy = {"_id": policy_id, "enabled": True, "name": "Test Policy"}
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (True, mock_policy, None)
+       
+       success, policy, error = await udm_api.get_firewall_policy(policy_id)
+       
+       assert success is True
+       assert policy == mock_policy
+       assert error is None
 
 @pytest.mark.asyncio
-async def test_toggle_traffic_rule_failure(udm_api):
-    rule_id = "1"
-    enabled = True
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (False, None, "Failed to toggle rule")
-
-        success, error = await udm_api.toggle_traffic_rule(rule_id, enabled)
-
-        assert success == False
-        assert "Failed to toggle rule" in error
-
-@pytest.mark.asyncio
-async def test_toggle_firewall_rule_success(udm_api):
-    rule_id = "1"
-    enabled = True
-    mock_rule = {"data": [{"_id": rule_id, "enabled": not enabled}]}
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.side_effect = [
-            (True, mock_rule, None),  # GET request
-            (True, None, None)  # PUT request
-        ]
-
-        success, error = await udm_api.toggle_firewall_rule(rule_id, enabled)
-
-        assert success == True
-        assert error is None
-        assert mock_request.call_count == 2
+async def test_get_firewall_policy_failure(udm_api):
+   policy_id = "test_id"
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (False, None, "API Error")
+       
+       success, policy, error = await udm_api.get_firewall_policy(policy_id)
+       
+       assert success is False
+       assert policy is None
+       assert error == "API Error"
 
 @pytest.mark.asyncio
-async def test_toggle_firewall_rule_failure(udm_api):
-    rule_id = "1"
-    enabled = True
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (False, None, "Failed to toggle rule")
-
-        success, error = await udm_api.toggle_firewall_rule(rule_id, enabled)
-
-        assert success == False
-        assert "Failed to toggle rule" in error
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_success(udm_api):
-    mock_response = {"data": "test"}
-    
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in:
-        mock_ensure_logged_in.return_value = True
-        mock_get.return_value.__aenter__.return_value.status = 200
-        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=mock_response)
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == True
-        assert data == mock_response
-        assert error is None
+async def test_toggle_firewall_policy_success(udm_api):
+   policy_id = "test_id"
+   mock_policy = {"_id": policy_id, "enabled": False}
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.side_effect = [
+           (True, mock_policy, None),  # GET response
+           (True, None, None)  # PUT response
+       ]
+       
+       success, error = await udm_api.toggle_firewall_policy(policy_id, True)
+       
+       assert success is True
+       assert error is None
+       assert mock_request.call_count == 2
 
 @pytest.mark.asyncio
-async def test_make_authenticated_request_retry_success(udm_api):
-    mock_response = {"data": "test"}
-    
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
-         patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-        mock_ensure_logged_in.side_effect = [True, True]
-        mock_get.return_value.__aenter__.return_value.status = 401
-        mock_get.return_value.__aenter__.return_value.text = AsyncMock(return_value="Unauthorized")
-        mock_get.return_value.__aenter__.side_effect = [
-            AsyncMock(status=401, text=AsyncMock(return_value="Unauthorized")),
-            AsyncMock(status=200, json=AsyncMock(return_value=mock_response))
-        ]
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == True
-        assert data == mock_response
-        assert error is None
-        assert mock_ensure_logged_in.call_count == 2
-        assert mock_sleep.call_count == 1
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_max_retries(udm_api):
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
-         patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-        mock_ensure_logged_in.return_value = True
-        mock_get.return_value.__aenter__.return_value.status = 401
-        mock_get.return_value.__aenter__.return_value.text = AsyncMock(return_value="Unauthorized")
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == False
-        assert data is None
-        assert "Request failed. Status: 401" in error
-        assert mock_ensure_logged_in.call_count == udm_api.max_retries
-        assert mock_sleep.call_count == udm_api.max_retries - 1
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_client_error(udm_api):
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
-         patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-        mock_ensure_logged_in.return_value = True
-        mock_get.side_effect = ClientError()
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == False
-        assert data is None
-        assert "Client error during request" in error
-        assert mock_ensure_logged_in.call_count == udm_api.max_retries
-        assert mock_sleep.call_count == udm_api.max_retries - 1
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_timeout(udm_api):
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
-         patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-        mock_ensure_logged_in.return_value = True
-        mock_get.side_effect = asyncio.TimeoutError()
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == False
-        assert data is None
-        assert error == "Request timed out"
-        assert mock_ensure_logged_in.call_count == udm_api.max_retries
-        assert mock_sleep.call_count == udm_api.max_retries - 1
-
-@pytest.mark.asyncio
-async def test_login_unexpected_error(udm_api):
-    with patch('aiohttp.ClientSession.post') as mock_post:
-        mock_post.side_effect = Exception("Unexpected error")
-
-        success, error = await udm_api.login()
-
-        assert success == False
-        assert "Unexpected error during login" in error
-
-@pytest.mark.asyncio
-async def test_get_traffic_rules_no_rules(udm_api):
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, [], None)
-
-        success, rules, error = await udm_api.get_traffic_rules()
-
-        assert success == True
-        assert rules == []
-        assert error is None
-
-@pytest.mark.asyncio
-async def test_get_firewall_rules_no_rules(udm_api):
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, {"data": []}, None)
-
-        success, rules, error = await udm_api.get_firewall_rules()
-
-        assert success == True
-        assert rules == []
-        assert error is None
-
-@pytest.mark.asyncio
-async def test_toggle_traffic_rule_not_found(udm_api):
-    rule_id = "nonexistent"
-    enabled = True
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, None, None)  # Simulate rule not found
-
-        success, error = await udm_api.toggle_traffic_rule(rule_id, enabled)
-
-        assert success == False
-        assert f"Rule with id {rule_id} not found" in error
-
-@pytest.mark.asyncio
-async def test_toggle_firewall_rule_not_found(udm_api):
-    rule_id = "nonexistent"
-    enabled = True
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, {"data": []}, None)  # Simulate rule not found
-
-        success, error = await udm_api.toggle_firewall_rule(rule_id, enabled)
-
-        assert success == False
-        assert f"Rule with id {rule_id} not found" in error
-
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_login_failure(udm_api):
-    with patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in:
-        mock_ensure_logged_in.return_value = False
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == False
-        assert data is None
-        assert error == "Failed to login"
-
-@pytest.mark.asyncio
-async def test_make_authenticated_request_unexpected_error(udm_api):
-    with patch('aiohttp.ClientSession.get') as mock_get, \
-         patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in:
-        mock_ensure_logged_in.return_value = True
-        mock_get.side_effect = Exception("Unexpected error")
-
-        success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
-
-        assert success == False
-        assert data is None
-        assert "Unexpected error during request" in error
+async def test_toggle_firewall_policy_get_failure(udm_api):
+   policy_id = "test_id"
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (False, None, "Failed to fetch policy")
+       
+       success, error = await udm_api.toggle_firewall_policy(policy_id, True)
+       
+       assert success is False
+       assert "Failed to fetch policy" in error
 
 @pytest.mark.asyncio
 async def test_get_traffic_routes_success(udm_api):
-    """Test successful retrieval of traffic routes."""
-    mock_routes = [
-        {
-            "_id": "6394f963e232e25ab3cbc597",
-            "description": "Test Route 1",
-            "enabled": True,
-            "matching_target": "INTERNET",
-            "target_devices": [{"client_mac": "00:11:22:33:44:55", "type": "CLIENT"}]
-        },
-        {
-            "_id": "6394fbd1e232e25ab3cbc7a2",
-            "description": "Test Route 2",
-            "enabled": False,
-            "matching_target": "DOMAIN",
-            "domains": [{"domain": "example.com"}]
-        }
-    ]
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, mock_routes, None)
-        
-        success, routes, error = await udm_api.get_traffic_routes()
-        
-        assert success is True
-        assert routes == mock_routes
-        assert error is None
-        mock_request.assert_called_once_with(
-            'get',
-            f'https://{udm_api.host}/proxy/network/v2/api/site/default/trafficroutes',
-            {'Accept': 'application/json'}
-        )
+   mock_routes = [
+       {
+           "_id": "route1",
+           "description": "Test Route 1",
+           "enabled": True,
+           "matching_target": "INTERNET"
+       },
+       {
+           "_id": "route2",
+           "description": "Test Route 2",
+           "enabled": False,
+           "matching_target": "DOMAIN"
+       }
+   ]
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (True, mock_routes, None)
+       
+       success, routes, error = await udm_api.get_traffic_routes()
+       
+       assert success is True
+       assert routes == mock_routes
+       assert error is None
 
 @pytest.mark.asyncio
 async def test_get_traffic_routes_failure(udm_api):
-    """Test failed retrieval of traffic routes."""
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (False, None, "API Error")
-        
-        success, routes, error = await udm_api.get_traffic_routes()
-        
-        assert success is False
-        assert routes is None
-        assert error == "API Error"
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (False, None, "API Error")
+       
+       success, routes, error = await udm_api.get_traffic_routes()
+       
+       assert success is False
+       assert routes is None
+       assert error == "API Error"
 
 @pytest.mark.asyncio
 async def test_toggle_traffic_route_success(udm_api):
-    """Test successful toggling of a traffic route."""
-    route_id = "6394f963e232e25ab3cbc597"
-    mock_route = {
-        "_id": route_id,
-        "description": "Test Route",
-        "enabled": False,
-        "matching_target": "INTERNET",
-        "target_devices": []
-    }
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request, \
-         patch.object(udm_api, 'get_traffic_routes') as mock_get_routes:
-        # Mock the GET request for all routes
-        mock_get_routes.return_value = (True, [mock_route], None)
-        
-        # Mock the PUT request for updating the route
-        mock_request.return_value = (True, None, None)
-        
-        success, error = await udm_api.toggle_traffic_route(route_id, True)
-        
-        assert success is True
-        assert error is None
-        
-        # Verify the PUT request was made with the correct data
-        expected_url = f'https://{udm_api.host}/proxy/network/v2/api/site/default/trafficroutes/{route_id}'
-        expected_headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
-        expected_data = {**mock_route, 'enabled': True}
-        
-        mock_request.assert_called_once_with('put', expected_url, expected_headers, expected_data)
-
-@pytest.mark.asyncio
-async def test_toggle_traffic_route_not_found(udm_api):
-    """Test toggling a non-existent traffic route."""
-    route_id = "nonexistent_id"
-    
-    with patch.object(udm_api, 'get_traffic_routes') as mock_get_routes:
-        mock_get_routes.return_value = (True, [], None)
-        
-        success, error = await udm_api.toggle_traffic_route(route_id, True)
-        
-        assert success is False
-        assert "Route with id nonexistent_id not found" in error
+   route_id = "route1"
+   mock_route = {
+       "_id": route_id,
+       "description": "Test Route",
+       "enabled": False
+   }
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.side_effect = [
+           (True, [mock_route], None),  # GET response
+           (True, None, None)  # PUT response
+       ]
+       
+       success, error = await udm_api.toggle_traffic_route(route_id, True)
+       
+       assert success is True
+       assert error is None
+       assert mock_request.call_count == 2
 
 @pytest.mark.asyncio
 async def test_toggle_traffic_route_get_failure(udm_api):
-    """Test failure to fetch routes when trying to toggle."""
-    route_id = "6394f963e232e25ab3cbc597"
-    
-    with patch.object(udm_api, 'get_traffic_routes') as mock_get_routes:
-        mock_get_routes.return_value = (False, None, "Failed to fetch routes")
-        
-        success, error = await udm_api.toggle_traffic_route(route_id, True)
-        
-        assert success is False
-        assert "Failed to fetch routes" in error
+   route_id = "route1"
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (False, None, "Failed to fetch routes")
+       
+       success, error = await udm_api.toggle_traffic_route(route_id, True)
+       
+       assert success is False
+       assert "Failed to fetch routes" in error
 
 @pytest.mark.asyncio
-async def test_toggle_traffic_route_update_failure(udm_api):
-    """Test failure when updating a traffic route."""
-    route_id = "6394f963e232e25ab3cbc597"
-    mock_route = {
-        "_id": route_id,
-        "description": "Test Route",
-        "enabled": False,
-        "matching_target": "INTERNET",
-        "target_devices": []
-    }
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request, \
-         patch.object(udm_api, 'get_traffic_routes') as mock_get_routes:
-        # Mock successful GET but failed PUT
-        mock_get_routes.return_value = (True, [mock_route], None)
-        mock_request.return_value = (False, None, "Update failed")
-        
-        success, error = await udm_api.toggle_traffic_route(route_id, True)
-        
-        assert success is False
-        assert "Failed to toggle route: Update failed" in error
+async def test_toggle_traffic_route_not_found(udm_api):
+   route_id = "nonexistent"
+   
+   with patch.object(udm_api, '_make_authenticated_request') as mock_request:
+       mock_request.return_value = (True, [], None)
+       
+       success, error = await udm_api.toggle_traffic_route(route_id, True)
+       
+       assert success is False
+       assert "Route with id nonexistent not found" in error
 
 @pytest.mark.asyncio
-async def test_toggle_traffic_route_preserve_data(udm_api):
-    """Test that toggling a route preserves all original data except enabled state."""
-    route_id = "6394f963e232e25ab3cbc597"
-    mock_route = {
-        "_id": route_id,
-        "description": "Test Route",
-        "enabled": False,
-        "matching_target": "DOMAIN",
-        "domains": [{"domain": "example.com", "ports": [80, 443]}],
-        "target_devices": [{"client_mac": "00:11:22:33:44:55", "type": "CLIENT"}],
-        "network_id": "network123",
-        "kill_switch_enabled": True,
-        "ip_addresses": ["192.168.1.1"],
-        "ip_ranges": ["10.0.0.0/24"]
-    }
-    
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request, \
-         patch.object(udm_api, 'get_traffic_routes') as mock_get_routes:
-        mock_get_routes.return_value = (True, [mock_route], None)
-        mock_request.return_value = (True, None, None)
-        
-        success, error = await udm_api.toggle_traffic_route(route_id, True)
-        
-        assert success is True
-        assert error is None
-        
-        # Verify all data was preserved except enabled state
-        expected_data = {**mock_route, 'enabled': True}
-        mock_request.assert_called_once()
-        actual_data = mock_request.call_args[0][3]
-        assert actual_data == expected_data
-        assert all(actual_data[key] == mock_route[key] for key in mock_route if key != 'enabled')
+async def test_make_authenticated_request_success(udm_api):
+   mock_response = {"data": "test"}
+   
+   with patch('aiohttp.ClientSession.get') as mock_get, \
+        patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in:
+       mock_ensure_logged_in.return_value = True
+       mock_get.return_value.__aenter__.return_value.status = 200
+       mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=mock_response)
+
+       success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
+
+       assert success == True
+       assert data == mock_response
+       assert error is None
 
 @pytest.mark.asyncio
-async def test_get_traffic_routes_empty_response(udm_api):
-    """Test handling of empty response when getting traffic routes."""
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, [], None)
-        
-        success, routes, error = await udm_api.get_traffic_routes()
-        
-        assert success is True
-        assert routes == []
-        assert error is None
+async def test_make_authenticated_request_retry_success(udm_api):
+   mock_response = {"data": "test"}
+   
+   with patch('aiohttp.ClientSession.get') as mock_get, \
+        patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
+        patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+       mock_ensure_logged_in.return_value = True
+       mock_get.return_value.__aenter__.return_value.status = 401
+       mock_get.return_value.__aenter__.return_value.text = AsyncMock(return_value="Unauthorized")
+       mock_get.return_value.__aenter__.side_effect = [
+           AsyncMock(status=401, text=AsyncMock(return_value="Unauthorized")),
+           AsyncMock(status=200, json=AsyncMock(return_value=mock_response))
+       ]
+
+       success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
+
+       assert success is True
+       assert data == mock_response
+       assert error is None
+       assert mock_sleep.call_count > 0
 
 @pytest.mark.asyncio
-async def test_get_traffic_routes_invalid_response(udm_api):
-    """Test handling of invalid response when getting traffic routes."""
-    with patch.object(udm_api, '_make_authenticated_request') as mock_request:
-        mock_request.return_value = (True, None, None)
-        
-        success, routes, error = await udm_api.get_traffic_routes()
-        
-        assert success is True
-        assert routes is None
-        assert error is None
+async def test_make_authenticated_request_max_retries(udm_api):
+   with patch('aiohttp.ClientSession.get') as mock_get, \
+        patch.object(udm_api, 'ensure_logged_in') as mock_ensure_logged_in, \
+        patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+       mock_ensure_logged_in.return_value = True
+       mock_get.return_value.__aenter__.return_value.status = 401
+       mock_get.return_value.__aenter__.return_value.text = AsyncMock(return_value="Unauthorized")
+
+       success, data, error = await udm_api._make_authenticated_request('get', 'https://test.com', {})
+
+       assert success is False
+       assert data is None
+       assert "Request failed. Status: 401" in error
+       assert mock_sleep.call_count == udm_api.max_retries - 1


### PR DESCRIPTION
Unifi has changed how you configured firewall and traffic rules with the release of v9. Once you migrate to the new [Firewall Zones](https://help.ui.com/hc/en-us/articles/115003173168-UniFi-Gateway-Zone-Based-Firewall), your riles will be consolodated into firewall policies, which have new api enpoints to manage them. For testing those new endpoints yourself, see my [API testing repository](https://github.com/sirkirby/bruno-udm-api).

* Removed support for getting and updating traffic and firewall rules
* Retained support for traffic routes, as they were not part of this migraiton
* Add support for getting all, getting individual, and modifying firewall policies

> [!NOTE]
> After upgrading in home assistant, you may need to manually delete the old traffic and firewall rule entities and you will have to update all of your dashboards with the new entities created for your same rules now prefixed with `firewall policy`