### PR TITLE
Update HACS button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Unifi Dream Machine (UDM) running network application 9.0.92 or later.
 
 ## Installation
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sirkirby&repository=unifi-network-rules&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sirkirby&repository=ha-udm-rule-manager&category=integration)
 
 OR
 


### PR DESCRIPTION
Clicking the HACS button doesn't work, because the README is still using the old repository URL.